### PR TITLE
Allow for ``:active`` on the Context

### DIFF
--- a/lib/segment/context.ex
+++ b/lib/segment/context.ex
@@ -4,6 +4,7 @@ defmodule Segment.Context do
   @library_version Mix.Project.get().project[:version]
 
   defstruct [
+    :active,
     :app,
     :campaign,
     :device,


### PR DESCRIPTION
This will allow for a ``Context`` to be used for a ``Track`` where the ``active`` attribute can be set specifically.